### PR TITLE
Link to  AnVIL portal instead of NHGRI AnVIL site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ This section will provide a more detailed description of projects.
 
 
 [_Bioconductor_]: https://bioconductor.org
-[_AnVIL_]: https://www.genome.gov/27569268/genomic-analysis-visualization-and-informatics-labspace-anvil/
+[_AnVIL_]: https://anvilproject.org
 [about]: about
 [AnVIL package]: https://github.com/Bioconductor/AnVIL
 [Training Materials]: training


### PR DESCRIPTION
Hi There, 

I am working with UCSC  AnVIL portal team and wanted to suggest this update to link directly to the AnVIL Portal now that it is available rather than the more generic NHGRI AnVIL site.  

Please reach out to me with any questions. 

Cheers and Thanks,
Dave Rogers